### PR TITLE
Explicitely link to gthread

### DIFF
--- a/multisense_utils/src/multisense-renderer/CMakeLists.txt
+++ b/multisense_utils/src/multisense-renderer/CMakeLists.txt
@@ -28,7 +28,7 @@ pods_install_headers(multisense_renderer.h
 pods_install_libraries(multisense-renderer)
 
 pods_install_pkg_config_file(multisense-renderer
-    LIBS -lmultisense-renderer
+    LIBS -lmultisense-renderer -lgthread-2.0
     REQUIRES bot2-vis bot2-frames 
     VERSION 0.0.1)
 


### PR DESCRIPTION
This maintains compatibility with cutting-edge LCM, which drops
gthread dependency and stops linking to it, revealing the lack
of this explicit link in this build
